### PR TITLE
Fix deployment bucket in build scripts.

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -14,7 +14,6 @@ jobs:
 
     env:
       STAGE_NAME: dev
-      AWS_DEPLOYMENT_BUCKET: ${{ secrets.S3_BUCKET_DEV }}
       POLLING_INTERVAL: 120
       BIGCOMMERCE_STORE_HASH: ${{ secrets.BIGCOMMERCE_STORE_HASH_DEV }}
       BIGCOMMERCE_TOKEN: ${{ secrets.BIGCOMMERCE_TOKEN_DEV }}
@@ -34,7 +33,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and upload artifacts
-        run: sh scripts/upload.sh
+        run: sh scripts/upload.sh ${{ secrets.S3_BUCKET_DEV }}
       - name: Deploy to AWS CloudFormation
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       STAGE_NAME: dev
+      AWS_DEPLOYMENT_BUCKET: ${{ secrets.S3_BUCKET_DEV }}
       POLLING_INTERVAL: 120
       BIGCOMMERCE_STORE_HASH: ${{ secrets.BIGCOMMERCE_STORE_HASH_DEV }}
       BIGCOMMERCE_TOKEN: ${{ secrets.BIGCOMMERCE_TOKEN_DEV }}
@@ -33,7 +34,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and upload artifacts
-        run: sh scripts/upload.sh ${{ secrets.S3_BUCKET_DEV }}
+        run: sh scripts/upload.sh ${{ env.AWS_DEPLOYMENT_BUCKET }}
       - name: Deploy to AWS CloudFormation
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -14,7 +14,6 @@ jobs:
 
     env:
       STAGE_NAME: prod
-      AWS_DEPLOYMENT_BUCKET: ${{ secrets.S3_BUCKET_PROD }}
       POLLING_INTERVAL: 480
       BIGCOMMERCE_STORE_HASH: ${{ secrets.BIGCOMMERCE_STORE_HASH_PROD }}
       BIGCOMMERCE_TOKEN: ${{ secrets.BIGCOMMERCE_TOKEN_PROD }}
@@ -34,7 +33,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and upload artifacts
-        run: sh scripts/upload.sh
+        run: sh scripts/upload.sh ${{ secrets.S3_BUCKET_PROD }}
       - name: Deploy to AWS CloudFormation
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       STAGE_NAME: prod
+      AWS_DEPLOYMENT_BUCKET: ${{ secrets.S3_BUCKET_PROD }}
       POLLING_INTERVAL: 480
       BIGCOMMERCE_STORE_HASH: ${{ secrets.BIGCOMMERCE_STORE_HASH_PROD }}
       BIGCOMMERCE_TOKEN: ${{ secrets.BIGCOMMERCE_TOKEN_PROD }}
@@ -33,7 +34,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and upload artifacts
-        run: sh scripts/upload.sh ${{ secrets.S3_BUCKET_PROD }}
+        run: sh scripts/upload.sh ${{ env.AWS_DEPLOYMENT_BUCKET }}
       - name: Deploy to AWS CloudFormation
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       STAGE_NAME: staging
+      AWS_DEPLOYMENT_BUCKET: ${{ secrets.S3_BUCKET_STAGING }}
       POLLING_INTERVAL: 120
       BIGCOMMERCE_STORE_HASH: ${{ secrets.BIGCOMMERCE_STORE_HASH_STAGING }}
       BIGCOMMERCE_TOKEN: ${{ secrets.BIGCOMMERCE_TOKEN_STAGING }}
@@ -33,7 +34,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and upload artifacts
-        run: sh scripts/upload.sh ${{ secrets.S3_BUCKET_STAGING }}
+        run: sh scripts/upload.sh ${{ env.AWS_DEPLOYMENT_BUCKET }}
       - name: Deploy to AWS CloudFormation
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -14,7 +14,6 @@ jobs:
 
     env:
       STAGE_NAME: staging
-      AWS_DEPLOYMENT_BUCKET: ${{ secrets.S3_BUCKET_STAGING }}
       POLLING_INTERVAL: 120
       BIGCOMMERCE_STORE_HASH: ${{ secrets.BIGCOMMERCE_STORE_HASH_STAGING }}
       BIGCOMMERCE_TOKEN: ${{ secrets.BIGCOMMERCE_TOKEN_STAGING }}
@@ -34,7 +33,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build and upload artifacts
-        run: sh scripts/upload.sh
+        run: sh scripts/upload.sh ${{ secrets.S3_BUCKET_STAGING }}
       - name: Deploy to AWS CloudFormation
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:

--- a/readme.md
+++ b/readme.md
@@ -286,6 +286,10 @@ The sample app comes with bash scripts to generate .zip files for each lambda fu
 sh scripts/build.sh
 ```
 
+You may then manually upload the .zip files in `build/` to your S3 deployment bucket.
+
+If you have the AWS CLI installed and configured with PutObject access to your S3 bucket, you may alternatively run `sh scripts/upload.sh <YOUR_S3_BUCKET>` to create the deployment packages and upload them.
+
 If your development environment does not support bash or you prefer to manually create the deployment packages, first run `npm install` in each of the folders in the `lambda` directory to install dependencies before creating a .zip file with the contents of each of those folders. Those files must be named `get-new-orders`, `new-orders-webhook`, and `process-new-orders` respectively. Make sure not to include the top-level folders in your .zip files, just the folder contents.
 
 Example: 

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -1,6 +1,6 @@
 sh scripts/build.sh
 echo "## Uploading new artifacts"
-aws s3 cp build/get-new-orders.zip s3://$AWS_DEPLOYMENT_BUCKET
-aws s3 cp build/new-orders-webhook.zip s3://$AWS_DEPLOYMENT_BUCKET
-aws s3 cp build/process-new-orders.zip s3://$AWS_DEPLOYMENT_BUCKET
-aws s3 cp cloudformation/stack.json s3://$AWS_DEPLOYMENT_BUCKET
+aws s3 cp build/get-new-orders.zip s3://$1
+aws s3 cp build/new-orders-webhook.zip s3://$1
+aws s3 cp build/process-new-orders.zip s3://$1
+aws s3 cp cloudformation/stack.json s3://$1


### PR DESCRIPTION
Issue reported by tester: error using upload.sh build script

Cause: upload.sh build script requires an env var for AWS_DEPLOYMENT_BUCKET. Steps to set the var were not documented.

Solution: Convert the env var to a parameter, and update readme with instructions to pass your S3 bucket name to the upload script as an env var when deploying from the Cloudformation console.